### PR TITLE
Add Function to Parsing Arguments with Quotation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export { parse } from "./parse.js";
 export { stringify } from "./stringify.js";

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -1,0 +1,10 @@
+import { parse } from "./parse";
+
+it("should parse the arguments", () => {
+  expect(parse('foo "bar baz" \'foo bar baz\' `foo "bar baz"`')).toEqual([
+    "foo",
+    "bar baz",
+    "foo bar baz",
+    `foo "bar baz"`,
+  ]);
+});

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,0 +1,18 @@
+const regex = /"([^"]*)"|'([^']*)'|`([^`]*)`|(\S+)/g;
+
+/**
+ * Converts a space-separated string into a list of arguments.
+ *
+ * This function parses the provided string, which contains arguments separated by spaces and possibly enclosed in quotes, into a list of arguments.
+ *
+ * @param str - The space-separated string to parse.
+ * @returns A list of arguments.
+ */
+export function parse(str: string): string[] {
+  const args: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(str)) !== null) {
+    args.push(match[1] ?? match[2] ?? match[3] ?? match[4]);
+  }
+  return args;
+}


### PR DESCRIPTION
This pull request resolves #6 by adding a new `parse` function to parse space-separated arguments in a string into a list of arguments. It also includes a new test for this functionality.