### PR TITLE
Remove Upload Package Step in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,4 +31,4 @@ jobs:
         run: pnpm test
 
       - name: Package Library
-        run: pnpm pack --out package.tgz
+        run: pnpm pack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,10 +32,3 @@ jobs:
 
       - name: Package Library
         run: pnpm pack --out package.tgz
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          path: package.tgz
-          if-no-files-found: error
-          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 dist/
 node_modules/
 
-package.tgz
+*.tgz


### PR DESCRIPTION
This pull request resolves #112 by removing the "Upload Package" step from the `build` workflow. Additionally, this change also updates the project to ignore the default output name for packaging the library.