### PR TITLE
Separate TypeScript Build Configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
         run: pnpm eslint
 
       - name: Check Types
-        run: pnpm tsc --noEmit
+        run: pnpm tsc
 
       - name: Test Library
         run: pnpm test

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,14 +14,12 @@ pre-commit:
       run: pnpm eslint --no-warn-ignored --fix {staged_files}
 
     - name: check types
-      run: pnpm tsc --noEmit
+      run: pnpm tsc
       glob:
-        - src/*.ts
+        - "*.ts"
         - .npmrc
         - pnpm-lock.yaml
         - tsconfig.json
-      exclude:
-        - src/*.test.ts
 
     - name: check diff
       run: git diff --exit-code {staged_files}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "tsc",
+    "prepack": "tsc -p tsconfig.build.json",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { parse } from "./parse";
+import { parse } from "./parse.js";
 
 it("should parse the arguments", () => {
   expect(parse('foo "bar baz" \'foo bar baz\' `foo "bar baz"`')).toEqual([

--- a/src/stringify.test.ts
+++ b/src/stringify.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { stringify } from "./stringify";
+import { stringify } from "./stringify.js";
 
 it("should stringify the arguments", () => {
   expect(stringify(["foo", "bar baz", `foo "bar baz"`])).toBe(

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/node24",
+  "include": ["src"],
+  "exclude": ["**/*.test.*"],
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "@tsconfig/node24",
-  "include": ["src"],
-  "exclude": ["**/*.test.*"],
   "compilerOptions": {
-    "declaration": true,
-    "outDir": "dist"
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This pull request resolves #187 by separating the TypeScript configurations into `tsconfig.json` for type checking and `tsconfig.build.json` for building the library.