### PR TITLE
Remove `packages` option from `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-packages:
-  - .
 allowBuilds:
   esbuild: true
   lefthook: true


### PR DESCRIPTION
This pull request resolves #438 by removing the `packages` option from `pnpm-workspace.yaml`, simplifying the workspace configuration.